### PR TITLE
test: add unsupported-type Scan case and clarify examples

### DIFF
--- a/time_zone_example_test.go
+++ b/time_zone_example_test.go
@@ -16,7 +16,10 @@ func ExampleTimeZone() {
 	}
 
 	fmt.Println(z.String())
-	fmt.Println(time.Time{}.In(z.Location()).Location().String())
+
+	// Location returns a *time.Location that can be applied to a time.Time.
+	loc := z.Location()
+	fmt.Println(time.Time{}.In(loc).Location().String())
 
 	// Output:
 	// America/New_York
@@ -24,6 +27,7 @@ func ExampleTimeZone() {
 }
 
 func ExampleTimeZone_zeroValue() {
+	// Loading "UTC" (or an empty string) always yields the zero value.
 	z, err := tz.LoadTimeZone("UTC")
 	if err != nil {
 		panic(err)
@@ -71,6 +75,7 @@ func ExampleTimeZone_Value() {
 func ExampleTimeZone_Value_zeroValue() {
 	var z tz.TimeZone
 
+	// The zero value is stored as the "UTC" string, never as NULL.
 	v, err := z.Value()
 	fmt.Printf("%v %T %v\n", v, v, err)
 

--- a/time_zone_test.go
+++ b/time_zone_test.go
@@ -305,6 +305,13 @@ func TestTimeZone_Scan(t *testing.T) {
 			wantTimeZone: mustLoadTimeZone(t, "America/New_York"),
 			wantErr:      true,
 		},
+		{
+			name:         "unsupported_type",
+			giveTimeZone: mustLoadTimeZone(t, "America/New_York"),
+			value:        []int{1},
+			wantTimeZone: mustLoadTimeZone(t, "America/New_York"),
+			wantErr:      true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a table-driven test entry in `TestTimeZone_Scan` that verifies `Scan` rejects an unsupported input type (`[]int`) while leaving the receiver unchanged
- Split a chained one-liner in `ExampleTimeZone` into a named variable for readability
- Add inline comments to `ExampleTimeZone_zeroValue` and `ExampleTimeZone_Value_zeroValue` to surface the UTC-as-zero-value and no-NULL invariants directly in the runnable docs

## Test plan

- [ ] `make test` passes (new test case covered by table-driven runner)
- [ ] `make lint` passes (no new linting issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)